### PR TITLE
fix: LE SAID in create credential scripts

### DIFF
--- a/internal/data/ecr-rules.json
+++ b/internal/data/ecr-rules.json
@@ -1,0 +1,12 @@
+{
+  "d": "EDIai3Wkd-Z_4cezz9nYEcCK3KNH5saLvZoS_84JL6NU",
+  "usageDisclaimer": {
+    "l": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+  },
+  "issuanceDisclaimer": {
+    "l": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+  },
+  "privacyDisclaimer": {
+    "l": "Privacy Considerations are applicable to QVI ECR AUTH vLEI Credentials.  It is the sole responsibility of QVIs as Issuees of QVI ECR AUTH vLEI Credentials to present these Credentials in a privacy-preserving manner using the mechanisms provided in the Issuance and Presentation Exchange (IPEX) protocol specification and the Authentic Chained Data Container (ACDC) specification.  https://github.com/WebOfTrust/IETF-IPEX and https://github.com/trustoverip/tswg-acdc-specification."
+  }
+}

--- a/internal/data/oor-rules.json
+++ b/internal/data/oor-rules.json
@@ -1,0 +1,9 @@
+{
+  "d": "EDIai3Wkd-Z_4cezz9nYEcCK3KNH5saLvZoS_84JL6NU",
+  "usageDisclaimer": {
+    "l": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+  },
+  "issuanceDisclaimer": {
+    "l": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+  }
+}

--- a/internal/scripts/create-ecr-auth-credential.sh
+++ b/internal/scripts/create-ecr-auth-credential.sh
@@ -14,6 +14,7 @@ passcode="$(security find-generic-password -w -a "${LOGNAME}" -s int-gar-passcod
 
 echo "Use `kli vc list` to determine the SAID of the legal entity (LE) credential issued to this LE by the QVI"
 read -p "Enter the SAID of the legal entity (LE) credential issued to this LE by the QVI: " -r le_said
+
 read -p "Enter your LEI : " -r lei
 read -p "Enter or Paste the AID of the recipient of the ECR credential: " -r AID
 read -p "Enter requested person legal name: " -r personLegalName

--- a/internal/scripts/create-oor-auth-credential.sh
+++ b/internal/scripts/create-oor-auth-credential.sh
@@ -14,6 +14,7 @@ passcode="$(security find-generic-password -w -a "${LOGNAME}" -s int-gar-passcod
 
 echo "Use `kli vc list` to determine the SAID of the legal entity (LE) credential issued to this LE by the QVI"
 read -p "Enter the SAID of the legal entity (LE) credential issued to this LE by the QVI: " -r le_said
+
 read -p "Enter your LEI : " -r lei
 read -p "Enter or Paste the AID of the recipient of the OOR credential: " -r AID
 read -p "Enter requested person legal name: " -r personLegalName

--- a/internal/scripts/grant-oor-credential-personal.sh
+++ b/internal/scripts/grant-oor-credential-personal.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+##################################################################
+##                                                              ##
+##          Script for issuing oor auth                         ##
+##                                                              ##
+##################################################################
+
+PWD=$(pwd)
+source $PWD/source.sh
+
+# Capture password
+passcode="$(security find-generic-password -w -a "${LOGNAME}" -s int-gar-passcode)"
+
+read -p "Enter the Alias of Sally to present this credential to: " -r recipient
+read -p "Enter the datetime to use: " -r datetime
+read -p "Enter the OOR credential SAID: " -r SAID
+
+kli ipex grant \
+    --name "${INT_GAR_NAME}" \
+    --alias "${INT_GAR_ALIAS}" \
+    --passcode "${passcode}" \
+    --said "${SAID}" \
+    --time "${datetime}" \
+    --recipient "${recipient}"

--- a/internal/scripts/key-cleanup.sh
+++ b/internal/scripts/key-cleanup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+rm -rfv "${HOME}/.gar" # Deletes the entire .gar directory from your home directory.
+rm -rfv "${HOME}/.keri" # Deletes the entire .keri directory from your home directory.
+mkdir "${HOME}/.gar"
+
+# Deletes the passcode for your local keystore from the Keychain.
+passcode_item="$(security find-generic-password -a "${LOGNAME}" -s int-gar-passcode 2> /dev/null)"
+if [ -n "${passcode_item}" ]; then
+  echo "Deleting passcode from Keychain"
+  security delete-generic-password -a "${LOGNAME}" -s int-gar-passcode
+else
+  echo "Passcode not found in Keychain, nothing to delete."
+fi
+
+# Deletes the salt for your local keystore from the Keychain.
+salt_item="$(security find-generic-password -a "${LOGNAME}" -s int-gar-salt 2> /dev/null)"
+if [ -n "${salt_item}" ]; then
+  echo "Deleting salt from Keychain"
+  security delete-generic-password -a "${LOGNAME}" -s int-gar-salt
+else
+  echo "Salt not found in Keychain, nothing to delete."
+fi


### PR DESCRIPTION
Fixes the LE SAID command interpolation problem we had due to either logging output or the syntax warning at the command line for the KLI commands.

This also adds the rules section for the ECR and OOR credentials.