### PR TITLE
docs: qvi rotation command docs

### DIFF
--- a/docs/rotating-qvi-group-aid.md
+++ b/docs/rotating-qvi-group-aid.md
@@ -1,0 +1,10 @@
+# Rotating the QVI group (multisig) AID
+
+When rotating the QVI group AID then the raw `kli.sh` script and `multisig-join.sh` must be used as follows for the GARs to approve the delegation.
+
+```bash
+# GAR 1
+./scripts/kli.sh delegate confirm --alias "GLEIF External AID" --interact
+# GAR 2
+./scripts/multisig-join.s
+```


### PR DESCRIPTION
On the most recent dry run we said we wanted to document how to approve the QVI group rotation.